### PR TITLE
Remove unused RxCocoa import which was breaking CocoaPods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ xcode_scheme: DrX #4
 xcode_sdk: iphonesimulator13.3
 
 before_install:
+  - pod lib lint
   - brew install carthage
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ xcode_sdk: iphonesimulator13.3
 
 before_install:
   - pod lib lint
+  - swift build
   - brew install carthage
 
 install:

--- a/DrX.podspec
+++ b/DrX.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'DrX'
-  s.version               = '3.2.0'
+  s.version               = '3.2.1'
   s.summary               = "The Rx doctor is in the house, curing all your ailments with simple-yet-expressive operators and extensions. Includes Cocoa Touch support!"
   s.description           = "DrX is a collection of convenience extensions of RxSwift which add new operators for concisely handling common patterns and/or scenarios. In addition to an agnostic core, DrX also supports iOS RxCocoa."
   s.license               = { type: 'MIT', file: 'LICENSE' }
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
     touch.dependency 'RxCocoa'
   end
 
+  s.dependency 'RxRelay'
   s.dependency 'RxSwift'
 
 end

--- a/DrX.xcodeproj/project.pbxproj
+++ b/DrX.xcodeproj/project.pbxproj
@@ -17,23 +17,23 @@
 		78D212A0202E3F3B0051B815 /* ZipSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D2129F202E3F3B0051B815 /* ZipSpec.swift */; };
 		78D212A2202E3F9F0051B815 /* Observable+BoolSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D212A1202E3F9F0051B815 /* Observable+BoolSpec.swift */; };
 		78D212A4202E40680051B815 /* CovariantSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D212A3202E40680051B815 /* CovariantSpec.swift */; };
-		94192B72219610440010C208 /* DrXCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B71219610440010C208 /* DrXCollectionReusableView.swift */; };
-		94192B752196106B0010C208 /* DrXCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B742196106B0010C208 /* DrXCollectionViewCell.swift */; };
-		94192B77219610BD0010C208 /* DrXReuse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B76219610BD0010C208 /* DrXReuse.swift */; };
-		94192B79219611320010C208 /* DrXTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B78219611320010C208 /* DrXTableViewCell.swift */; };
-		94192B7B219611890010C208 /* DrXTableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B7A219611890010C208 /* DrXTableViewHeaderFooterView.swift */; };
 		942375D221BAA7D30072B2ED /* RelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942375D121BAA7D30072B2ED /* RelayType.swift */; };
 		942375D721BAA8870072B2ED /* AnyRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942375D621BAA8870072B2ED /* AnyRelay.swift */; };
 		942375D921BAA9370072B2ED /* Bind+AnyRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942375D821BAA9370072B2ED /* Bind+AnyRelay.swift */; };
 		949D2C0D20A5D8A100A8C1A7 /* Observable+KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D2C0C20A5D8A100A8C1A7 /* Observable+KeyPath.swift */; };
-		949D2C0F20A5DAE500A8C1A7 /* DrX+UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D2C0E20A5DAE500A8C1A7 /* DrX+UITableView.swift */; };
 		949D2C1120A5DB8500A8C1A7 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D2C1020A5DB8500A8C1A7 /* Do.swift */; };
 		94B6AF8A20F7C23700E185FC /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B6AF8920F7C23700E185FC /* Disposable.swift */; };
-		94CC37B32031E9B40018C210 /* DrX+UIPreviewing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CC37B22031E9B40018C210 /* DrX+UIPreviewing.swift */; };
 		B503F84823EB11DE00082419 /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B578765923EA2DF2004D4E21 /* RxRelay.framework */; };
 		B503F84B23EB126900082419 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B568B3E421F69E9300A48166 /* RxCocoa.framework */; };
 		B503F84D23EB126B00082419 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B568B3E321F69E9300A48166 /* RxSwift.framework */; };
 		B503F84F23EB152600082419 /* RxRelay.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = B578765923EA2DF2004D4E21 /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B503F87223EB50B800082419 /* DrXCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B71219610440010C208 /* DrXCollectionReusableView.swift */; };
+		B503F87323EB50B800082419 /* DrXCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B742196106B0010C208 /* DrXCollectionViewCell.swift */; };
+		B503F87423EB50B800082419 /* DrXReuse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B76219610BD0010C208 /* DrXReuse.swift */; };
+		B503F87523EB50B800082419 /* DrXTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B78219611320010C208 /* DrXTableViewCell.swift */; };
+		B503F87623EB50B800082419 /* DrXTableViewHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94192B7A219611890010C208 /* DrXTableViewHeaderFooterView.swift */; };
+		B503F87723EB50B800082419 /* DrX+UIPreviewing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CC37B22031E9B40018C210 /* DrX+UIPreviewing.swift */; };
+		B503F87823EB50B800082419 /* DrX+UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949D2C0E20A5DAE500A8C1A7 /* DrX+UITableView.swift */; };
 		B54E9C6F1FC356B9000301C6 /* DrX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B54E9C651FC356B9000301C6 /* DrX.framework */; };
 		B568B3DE21F69E4D00A48166 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B568B3DC21F69E4D00A48166 /* Quick.framework */; };
 		B568B3DF21F69E4D00A48166 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B568B3DD21F69E4D00A48166 /* Nimble.framework */; };
@@ -379,26 +379,26 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				949D2C0F20A5DAE500A8C1A7 /* DrX+UITableView.swift in Sources */,
-				94192B72219610440010C208 /* DrXCollectionReusableView.swift in Sources */,
-				94192B79219611320010C208 /* DrXTableViewCell.swift in Sources */,
 				94B6AF8A20F7C23700E185FC /* Disposable.swift in Sources */,
 				78D21294202E37130051B815 /* Replace.swift in Sources */,
+				B503F87523EB50B800082419 /* DrXTableViewCell.swift in Sources */,
+				B503F87323EB50B800082419 /* DrXCollectionViewCell.swift in Sources */,
 				78D2129A202E38200051B815 /* Zip.swift in Sources */,
 				949D2C1120A5DB8500A8C1A7 /* Do.swift in Sources */,
+				B503F87223EB50B800082419 /* DrXCollectionReusableView.swift in Sources */,
 				78D21296202E376F0051B815 /* EraseElements.swift in Sources */,
 				942375D721BAA8870072B2ED /* AnyRelay.swift in Sources */,
 				78D2129C202E3CFA0051B815 /* Observable+Bool.swift in Sources */,
+				B503F87823EB50B800082419 /* DrX+UITableView.swift in Sources */,
 				949D2C0D20A5D8A100A8C1A7 /* Observable+KeyPath.swift in Sources */,
-				94192B7B219611890010C208 /* DrXTableViewHeaderFooterView.swift in Sources */,
-				94CC37B32031E9B40018C210 /* DrX+UIPreviewing.swift in Sources */,
-				94192B77219610BD0010C208 /* DrXReuse.swift in Sources */,
-				94192B752196106B0010C208 /* DrXCollectionViewCell.swift in Sources */,
+				B503F87723EB50B800082419 /* DrX+UIPreviewing.swift in Sources */,
 				942375D921BAA9370072B2ED /* Bind+AnyRelay.swift in Sources */,
+				B503F87423EB50B800082419 /* DrXReuse.swift in Sources */,
 				78D21292202E28550051B815 /* Covariance.swift in Sources */,
 				78D2128E202E246C0051B815 /* DrXNamespace.swift in Sources */,
 				78D21298202E37F40051B815 /* Optional.swift in Sources */,
 				942375D221BAA7D30072B2ED /* RelayType.swift in Sources */,
+				B503F87623EB50B800082419 /* DrXTableViewHeaderFooterView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrX/Sources/Cocoa Touch/DrX+UIPreviewing.swift
+++ b/DrX/Sources/Cocoa Touch/DrX+UIPreviewing.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxCocoa
 import RxSwift
@@ -78,3 +79,4 @@ public extension Reactive where Base: UITableView {
     }
 
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/DrX+UITableView.swift
+++ b/DrX/Sources/Cocoa Touch/DrX+UITableView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxCocoa
 import RxSwift
@@ -16,3 +17,4 @@ public extension Reactive where Base: UITableView {
     }
 
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/Reusable Views/DrXCollectionReusableView.swift
+++ b/DrX/Sources/Cocoa Touch/Reusable Views/DrXCollectionReusableView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxSwift
 import UIKit
@@ -16,3 +17,4 @@ open class DrXCollectionReusableView: UICollectionReusableView, DrXReuse {
     }
     
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/Reusable Views/DrXCollectionViewCell.swift
+++ b/DrX/Sources/Cocoa Touch/Reusable Views/DrXCollectionViewCell.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxSwift
 import UIKit
@@ -16,3 +17,4 @@ open class DrXCollectionViewCell: UICollectionViewCell, DrXReuse {
     }
     
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/Reusable Views/DrXReuse.swift
+++ b/DrX/Sources/Cocoa Touch/Reusable Views/DrXReuse.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxSwift
 import UIKit
@@ -18,3 +19,4 @@ public protocol DrXReuse: AnyObject {
     func prepareForReuse()
     
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/Reusable Views/DrXTableViewCell.swift
+++ b/DrX/Sources/Cocoa Touch/Reusable Views/DrXTableViewCell.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxSwift
 import UIKit
@@ -16,3 +17,4 @@ open class DrXTableViewCell: UITableViewCell, DrXReuse {
     }
     
 }
+#endif

--- a/DrX/Sources/Cocoa Touch/Reusable Views/DrXTableViewHeaderFooterView.swift
+++ b/DrX/Sources/Cocoa Touch/Reusable Views/DrXTableViewHeaderFooterView.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import Foundation
 import RxSwift
 import UIKit
@@ -16,3 +17,4 @@ open class DrXTableViewHeaderFooterView: UITableViewHeaderFooterView, DrXReuse {
     }
     
 }
+#endif

--- a/DrX/Sources/Core/Relays/AnyRelay.swift
+++ b/DrX/Sources/Core/Relays/AnyRelay.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxCocoa
+import RxRelay
 import RxSwift
 
 /// Provides a type-erased interface for relays and relay-like types or controls.
@@ -32,7 +32,7 @@ public struct AnyRelay<Element>: RelayType {
             AnyObserver { event in
                 switch event {
                 case .next(let next): accept(next)
-                case .error(_): break // TODO : fatalError("Binding error to relay: \(error)")
+                case .error(let error): fatalError("Binding error to relay: \(error)")
                 case .completed: return
                 }
             }

--- a/DrX/Sources/Core/Relays/Bind+AnyRelay.swift
+++ b/DrX/Sources/Core/Relays/Bind+AnyRelay.swift
@@ -7,17 +7,18 @@
 //
 
 import Foundation
-import RxCocoa
+import RxRelay
 import RxSwift
 
 public extension ObservableType {
-    
+
     func bind(to relay: AnyRelay<Element>) -> Disposable {
-        return bind(to: relay.asObserver())
+        return subscribe(relay.asObserver())
     }
-    
+
     func bind(to relay: AnyRelay<Element?>) -> Disposable {
-        return bind(to: relay.asObserver())
+        return map(Optional.some)
+            .subscribe(relay.asObserver())
     }
-    
+
 }

--- a/DrX/Sources/Core/Relays/RelayType.swift
+++ b/DrX/Sources/Core/Relays/RelayType.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxCocoa
+import RxRelay
 import RxSwift
 
 /// Represents a push style sequence which may also observe other sequences or raw values by directly

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 


### PR DESCRIPTION
Fix CocoaPods by requiring RxRelay and writing workaround for `bind` which is in RxCocoa and not RxSwift for the AnyRelay type introduced in 3.2.0.

Adds `swift build` to the Travis steps to validate that SPM can build the project.